### PR TITLE
Fix apparent typo in NotUpperCaseConstructor

### DIFF
--- a/src/fsharp/FSStrings.resx
+++ b/src/fsharp/FSStrings.resx
@@ -163,7 +163,7 @@
     <value>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</value>
   </data>
   <data name="NotUpperCaseConstructor" xml:space="preserve">
-    <value>Discriminated union cases and exception labels must be uppercase identifiers</value>
+    <value>Discriminated union cases and exception labels must begin with uppercase letters</value>
   </data>
   <data name="PossibleOverload" xml:space="preserve">
     <value>Possible overload: '{0}'. {1}.</value>


### PR DESCRIPTION
Fix compiler warning message 'NotUpperCaseConstructor': cases should _begin with_ upper case, not be all upper case as warning previously suggested
